### PR TITLE
Added Laravel official VS code extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Version 1.1.0
+
+- Added "Laravel" extension
+
+## Version 1.0.0
+
+- Added "Auto Rename Tag" extension
+- Added "Material Icon Theme" extension
+- Added "SQLite3 Editor" extension
+- Added "Alpine.js Intellisense" extension
+- Added "Alpine.js Syntax Highlight" extension
+- Removed "VS Code Icons" extension
+- Removed "SQLite" extension
+
 ## Version 0.0.1 (Initial Release)
 
 - Initial release of the Hatiar - Useful Laravel Extension Pack.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 
 ## Available Extensions
 
+- **Laravel**: Official Laravel VS Code Extension.
 - **Auto Rename Tag**: Auto rename paired HTML/XML tag.
 - **Intelephense Client**: Supercharge your Laravel development with enhanced code intelligence.
 - **PHPfmt**: Automatically format your PHP code for consistency and readability.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Hatiar - Useful Laravel Extension Pack",
   "description": "A handpicked collection of useful VS Code extension packs designed to simplify Laravel development, carefully crafted by @alnahian2003",
   "publisher": "alnahian2003",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "engines": {
     "vscode": "^1.83.0"
   },
@@ -27,6 +27,7 @@
     "url": "https://github/alnahian2003"
   },
   "extensionPack": [
+    "laravel.vscode-laravel",
     "formulahendry.auto-rename-tag",
     "bmewburn.vscode-intelephense-client",
     "kokororin.vscode-phpfmt",


### PR DESCRIPTION
In this PR, I've added the [Laravel official VS code extension](https://marketplace.visualstudio.com/items?itemName=laravel.vscode-laravel).